### PR TITLE
Add promise support for add/set/del/rest & remove xtend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
   * get, set, del and reset methods now returns a promise if cb hasn't been passed.
   * In some cases keys test could fail without a delay between set key and get cachedump.
   1 second delay added for get keys test.
+  * Removed not in use package xtend from the deps.
 
 # 2.3.0 (2021-01-04)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+  * get, set, del and reset methods now returns a promise if cb hasn't been passed.
+  * In some cases keys test could fail without a delay between set key and get cachedump.
+  1 second delay added for get keys test.
+
 # 2.3.0 (2021-01-04)
 
 * Updated `memcache-plus` version to 0.2.22

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "standard": "7.1.2"
   },
   "dependencies": {
-    "memcache-plus": "0.2.22",
+    "memcache-plus": "0.2.22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
   },
   "dependencies": {
     "memcache-plus": "0.2.22",
-    "xtend": "4.0.1"
   }
 }

--- a/spec/lib/memcached-store-spec.js
+++ b/spec/lib/memcached-store-spec.js
@@ -1,5 +1,8 @@
 /*global describe, it, expect, beforeAll */
 
+// Uncomment line below to enable memcache-plus debug logging.
+// process.env.DEBUG = 'memcache-plus:*'
+
 var config = require('../config.json')
 var memcachedStore = require('../../index')
 
@@ -125,11 +128,13 @@ describe('keys', function () {
       expect(err).toBe(null)
 
       memcachedCache.set('foo', 'bar', function () {
-        memcachedCache.keys(function (err, keys) {
-          expect(err).toBe(null)
-          expect(keys.length).toBe(1)
-          done()
-        })
+        setTimeout(function () {
+          memcachedCache.keys(function (err, keys) {
+            expect(err).toBe(null)
+            expect(keys.length).toBe(1)
+            done()
+          })
+        }, 1000)
       })
     })
   })


### PR DESCRIPTION
`npm` romon2002

- get, set, del and reset methods now returns a promise if cb hasn't been passed.
- In some cases keys test could fail without a delay between set key and get cachedump. 1 second delay added for get keys test.
- Removed not in use package xtend from the deps.